### PR TITLE
Add logger

### DIFF
--- a/M1_Library/Common.h
+++ b/M1_Library/Common.h
@@ -4,26 +4,26 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#define RAS_L 2
-#define CAS_L 3
-#define IN_L 18
-#define RD_L 19 // Defined as PD2 on Port D
-#define OUT_L 38
-#define WR_L 40
-#define CR2 42
-#define CR1 43
-#define INTAK_L 44
-#define RST_L 45
-#define WAIT_L 46
-#define TEST_L 47
-#define INT_L 48
-#define MUX_L 49
+#define RAS_L     2
+#define CAS_L     3
+#define IN_L      18
+#define RD_L      19  // Defined as PD2 on Port D
+#define OUT_L     38
+#define WR_L      40
+#define CR2       42
+#define CR1       43
+#define INTAK_L   44
+#define RST_L     45
+#define WAIT_L    46
+#define TEST_L    47
+#define INT_L     48
+#define MUX_L     49 
 
-#define VID 62
-#define CASS_IN 68
-#define CASS_OUT 69
+#define VID       62
+#define CASS_IN   68
+#define CASS_OUT  69
 
 // Pins not marked on shield: 39, 41, 50, 51
-#define BUSAK_L 41 // optional hookup, future support
+#define BUSAK_L   41  // optional hookup, future support
 
 #endif // COMMON_H

--- a/M1_Library/ILogger.h
+++ b/M1_Library/ILogger.h
@@ -1,0 +1,12 @@
+#ifndef ILOGGER_H
+#define ILOGGER_H
+
+class ILogger
+{
+public:
+    virtual void info(const char *fmt, ...) = 0;
+    virtual void warn(const char *fmt, ...) = 0;
+    virtual void err(const char *fmt, ...) = 0;
+};
+
+#endif /* ILOGGER_H */

--- a/M1_Library/Keyboard.cpp
+++ b/M1_Library/Keyboard.cpp
@@ -6,8 +6,8 @@
     - need to test with numeric keypad
 */
 
-#include "Keyboard.h"
-#include "Model1.h"
+#include "./Keyboard.h"
+#include "./Model1.h"
 
 // Look-up table for uppercase characters
 const uint8_t lookupTable[8][8] = {
@@ -21,8 +21,10 @@ const uint8_t lookupTable[8][8] = {
 };
 
 // Constructor
-Keyboard::Keyboard(Model1 *model) : model1(model)
+Keyboard::Keyboard(ILogger *logger, Model1 *model)
 {
+  model1 = model;
+  _logger = logger;
 }
 
 // Decodes key from keyboard, supports shift key. Does not support multiple keys being

--- a/M1_Library/Keyboard.h
+++ b/M1_Library/Keyboard.h
@@ -6,6 +6,7 @@
 #include <Arduino.h>
 #include "Common.h"
 #include "Utils.h"
+#include "./ILogger.h"
 
 #define KEYBOARD_MEM_ADDRESS 0x3800
 #define KEYBOARD_SHIFT_KEY 0x3880
@@ -15,13 +16,13 @@ class Model1; // Forward declaration
 class Keyboard
 {
 public:
-  Keyboard(Model1 *model);
+  Keyboard(ILogger *logger, Model1 *model);
 
-  Keyboard();
   uint8_t scanKeyboard();
 
 private:
   Model1 *model1;
+  ILogger *_logger;
 };
 
 #endif // KEYBOARD_H

--- a/M1_Library/M1_Library.ino
+++ b/M1_Library/M1_Library.ino
@@ -3,21 +3,26 @@
 #include <Arduino.h>
 #include "Model1.h"
 #include "Utils.h"
+#include "./SerialLogger.h"
 
-Model1 m1;
+Model1 *m1;
+SerialLogger *logger;
 
 char splashMsg[] = "RETROSTACK M1 TEST HARNESS LIBRARY - V";
 float version = 0.91; // Version
 
 void setup()
 {
-
   // Initialize serial communication at 500000 baud rate
   Serial.begin(500000);
   Serial.println("\n");
   Serial.print(splashMsg);
   Serial.println(version, 2); // Print the version with 3 decimal places
-  printLine(F("Program setup complete."));
+
+  logger = new SerialLogger();
+  m1 = new Model1(logger);
+
+  logger->info("Program setup complete.");
 
   // run examples
   examples();
@@ -34,55 +39,55 @@ void examples()
 {
 
   /* Setup the Model1 first and go immediately into TEST mode*/
-  m1.init();
+  m1->init();
 
   /*---------- Shield PIN statuses ---------*/
   if (0)
   {
-    m1.displayCtrlPinStatus(false);
+    m1->displayCtrlPinStatus();
   }
 
   /*---------- VIDEO ----------*/
-  m1.video.cls();
-  m1.video.printToScreen("RETROSHACK TEST HARNESS LIBRARY", 16, 0);
-  m1.video.printToScreen("\n\nENABLE THE 'IF()' BLOCKS IN THE ARDUINO CODE TO RUN EXAMPLES");
+  m1->video.cls();
+  m1->video.printToScreen("RETROSHACK TEST HARNESS LIBRARY", 16, 0);
+  m1->video.printToScreen("\n\nENABLE THE 'IF()' BLOCKS IN THE ARDUINO CODE TO RUN EXAMPLES");
 
   if (0)
   {
     // TIP: comment out all the features first and then uncomment the feature you wish to review
 
     // Fill with a pattern
-    m1.video.fillVRAMwithPattern(false, "TRS-80", 0x3D00, 0x3D3F);
+    m1->video.fillVRAMwithPattern("TRS-80", 0x3D00, 0x3D3F);
 
     // lowercase mod check
-    printLine("Lowercase mod detected: ", (m1.video.lowercaseModExists(true) ? "Yes" : "No"));
+    logger->info("Lowercase mod detected: %s", (m1->video.lowercaseModExists() ? "Yes" : "No"));
 
     // TODO: this is need as as the display ends up in the 32 character mode
     // not sure if it is due to contention with the video refresh circuitry.
     // And doesn't resolve issue 100% time, might be the board issue.
-    m1.video.cls();
+    m1->video.cls();
 
     // display font set
-    m1.video.displayCharacterSet();
+    m1->video.displayCharacterSet();
 
     // read VRAM and sent it to serial port
-    m1.video.readVRAM(true, true, true);  // show values in hex
-    m1.video.readVRAM(true, false, true); // show values in ASCII
+    m1->video.readVRAM(true, true);  // show values in hex
+    m1->video.readVRAM(false, true); // show values in ASCII
 
     // fill screen (full or partial)
-    m1.video.fillVRAM(true, '-', 0x3DC0, 0x3DFF);
+    m1->video.fillVRAM('-', 0x3DC0, 0x3DFF);
 
     // write a byte
     uint8_t writeByte = '*';
-    m1.setAddressLinesToOutput();              // do this once
-    m1.setDataLinesToOutput();                 // do this once
-    m1.video.writeByteVRAM(0x3CFF, writeByte); // do this per mem address
+    m1->setAddressLinesToOutput();              // do this once
+    m1->setDataLinesToOutput();                 // do this once
+    m1->video.writeByteVRAM(0x3CFF, writeByte); // do this per mem address
 
     // read a byte
-    m1.setAddressLinesToOutput();                     // do this once
-    m1.setDataLinesToInput();                         // do this once
-    uint8_t readByte = m1.video.readByteVRAM(0x3CFF); // do this per mem address
-    printLine("Wrote and read back: ", writeByte, "h, ", (char)readByte);
+    m1->setAddressLinesToOutput();                     // do this once
+    m1->setDataLinesToInput();                         // do this once
+    uint8_t readByte = m1->video.readByteVRAM(0x3CFF); // do this per mem address
+    logger->info("Wrote and read back: %dh, %d", writeByte, (char)readByte);
   }
 
   /*---------- KEYBOARD ----------*/
@@ -90,13 +95,9 @@ void examples()
   {
     while (1)
     {
-      uint8_t key = m1.keyboard.scanKeyboard();
+      uint8_t key = m1->keyboard.scanKeyboard();
       if (key != 0)
-      {
-        sprintf(stringBuffer, "Key: %2X, %c", key, (char)key);
-        printLine(stringBuffer);
-        // Serial.println((char)key);
-      }
+        logger->info("Key: %2X, %c", key, (char)key);
     }
   }
 
@@ -104,16 +105,15 @@ void examples()
   if (0)
   {
     // get ROM checksum
-    uint32_t checksum = m1.rom.getROMChecksum(false);
-    sprintf(stringBuffer, "ROM Checksum: %08lX", (unsigned long)checksum);
-    printLine(stringBuffer);
+    uint32_t checksum = m1->rom.getROMChecksum(false);
+    logger->info("ROM Checksum: %08lX", checksum);
 
     // Is the ROM checksum a known valid value
-    m1.rom.isROMValid(checksum, true);
-    printLine("ROM version ", m1.rom.romVersion, ", is it valid? ", (m1.rom.isValid ? "Y" : "N"));
+    m1->rom.isROMValid(checksum, true);
+    logger->info("ROM version %s, is it valid? %s", m1->rom.romVersion, (m1->rom.isValid ? "Y" : "N"));
 
     // dump ROM to serial port
-    m1.rom.dump();
+    m1->rom.dump();
   }
 
   /*---------- DRAM ----------*/
@@ -121,8 +121,8 @@ void examples()
 
   // At this point reset you can release the bus by setting address, data and control lines
   // to INPUTs and drive TEST* high
-  // m1.setAddressLinesToInput();
-  // m1.setDataLinesToInput();
-  // m1.setAllPinsPortsToInput();
-  // m1.setTESTPin(1);
+  // m1->setAddressLinesToInput();
+  // m1->setDataLinesToInput();
+  // m1->setAllPinsPortsToInput();
+  // m1->setTESTPin(1);
 }

--- a/M1_Library/Model1.cpp
+++ b/M1_Library/Model1.cpp
@@ -3,15 +3,15 @@
 
 #include "Model1.h"
 
-Model1::Model1() : video(this), keyboard(this), rom(this)
+Model1::Model1(ILogger *logger) : video(logger, this), keyboard(logger, this), rom(logger, this)
 {
-  // Constructor implementation (if needed)
+  _logger = logger;
 }
 
 // Initialization code for Model1
 void Model1::init()
 {
-  printLine("Initalizing shield and entering TEST mode.");
+  _logger->info("Initalizing shield and entering TEST mode.");
   initControlPins();
   setAddressLinesToInput();
   setDataLinesToInput();
@@ -22,13 +22,13 @@ void Model1::init()
 }
 
 // Display status of control pins. WARNING - set all control pins to input, excluding TEST*
-void Model1::displayCtrlPinStatus(bool silent)
+void Model1::displayCtrlPinStatus()
 {
   const int pins[] = {BUSAK_L, CAS_L, CR1, CR2, IN_L, INTAK_L, INT_L, MUX_L, OUT_L, RAS_L, RD_L, RST_L, VID, WAIT_L, WR_L, CASS_IN, CASS_OUT, VID};
   const char *pinNames[] = {"BUSAK_L", "CAS_L", "CR1", "CR2", "IN_L", "INTAK_L", "INT_L", "MUX_L", "OUT_L", "RAS_L", "RD_L", "RST_L", "WAIT_L", "WR_L", "CASS_IN", "CASS_OUT", "VID"};
   const int pinCount = sizeof(pins) / sizeof(pins[0]);
 
-  SILENT_PRINTLN(silent, "Displaying pin statuses.");
+  _logger->info("Displaying pin statuses.");
 
   for (int i = 0; i < pinCount - 1; ++i)
   {
@@ -42,9 +42,9 @@ void Model1::displayCtrlPinStatus(bool silent)
 
 // Init all ATMega pins, except for TEST_L pin as it should be set at start of program
 // and this will allow for 'resetting' the pins without leaving TEST mode
-void Model1::initControlPins(bool silent)
+void Model1::initControlPins()
 {
-  SILENT_PRINTLN(silent, "Settting all PINS except TEST* to INPUT.");
+  _logger->info("Settting all PINS except TEST* to INPUT.");
   pinMode(BUSAK_L, INPUT);
   pinMode(CAS_L, INPUT);
   pinMode(CR1, INPUT);
@@ -62,9 +62,9 @@ void Model1::initControlPins(bool silent)
 }
 
 // Set ATMega pins and ports to input, except for TEST*
-void Model1::setAllPinsPortsToInput(bool silent)
+void Model1::setAllPinsPortsToInput()
 {
-  SILENT_PRINTLN(silent, "Settting all PINS and PORTS to INPUT.");
+  _logger->info("Settting all PINS and PORTS to INPUT.");
   initControlPins();
   setAddressLinesToInput();
   setDataLinesToInput();
@@ -100,18 +100,18 @@ void Model1::setDataLinesToOutput()
 }
 
 // Set bus TEST* pin to active low or to high
-void Model1::setTESTPin(int state, bool silent)
+void Model1::setTESTPin(int state)
 {
   // TEST pin is active low
   if (state == 0)
   {
-    SILENT_PRINTLN(silent, "Setting TEST* to LOW (active).");
+    _logger->info("Setting TEST* to LOW (active).");
     pinMode(TEST_L, OUTPUT);
     digitalWrite(TEST_L, LOW);
   }
   else
   {
-    SILENT_PRINTLN(silent, "Setting TEST* to HIGH (inactive).");
+    _logger->info("Setting TEST* to HIGH (inactive).");
     pinMode(TEST_L, OUTPUT);
     digitalWrite(TEST_L, HIGH);
     pinMode(TEST_L, INPUT);

--- a/M1_Library/Model1.h
+++ b/M1_Library/Model1.h
@@ -9,21 +9,25 @@
 #include "ROM.h"
 #include "Utils.h"
 #include "Video.h"
+#include "./ILogger.h"
 
 class Model1
 {
+private:
+  ILogger *_logger;
+
 public:
-  Model1();
+  Model1(ILogger *logger);
   void init();
 
-  void displayCtrlPinStatus(bool silent = true);
-  void initControlPins(bool silent = true);
+  void displayCtrlPinStatus();
+  void initControlPins();
   void setAddressLinesToInput();
   void setAddressLinesToOutput(uint16_t memAddress = 0x3C00);
-  void setAllPinsPortsToInput(bool silent = true);
+  void setAllPinsPortsToInput();
   void setDataLinesToInput();
   void setDataLinesToOutput();
-  void setTESTPin(int state, bool silent = true);
+  void setTESTPin(int state);
   void turnOffReadWriteRASLines();
 
   Video video;

--- a/M1_Library/NoopLogger.cpp
+++ b/M1_Library/NoopLogger.cpp
@@ -1,0 +1,18 @@
+#include <arduino.h>
+
+#include "./NoopLogger.h"
+
+void NoopLogger::log(const char *fmt, ...)
+{
+    // Do nothing
+}
+
+void NoopLogger::warn(const char *fmt, ...)
+{
+    // Do nothing
+}
+
+void NoopLogger::err(const char *fmt, ...)
+{
+    // Do nothing
+}

--- a/M1_Library/NoopLogger.h
+++ b/M1_Library/NoopLogger.h
@@ -1,0 +1,16 @@
+#ifndef NOOP_LOGGER_H
+#define NOOP_LOGGER_H
+
+#include <Arduino.h>
+
+#include "./ILogger.h"
+
+class NoopLogger : public ILogger
+{
+public:
+    void log(const char *fmt, ...);
+    void warn(const char *fmt, ...);
+    void err(const char *fmt, ...);
+};
+
+#endif /* NOOP_LOGGER_H */

--- a/M1_Library/ROM.cpp
+++ b/M1_Library/ROM.cpp
@@ -6,30 +6,32 @@
 
 // Thanks to Ira @ trs-80.com: https://www.trs-80.com/wordpress/roms/checksums-mod-1/
 M1_ROMs romTable[] = {
-    {"1.0\0", 0xAE5D, 0xDA84, 0x4002, 0xD8E9DFA7, "Y\0"},
-    {"1.1\0", 0xAE60, 0xDA45, 0x40E0, 0x2DE3AFEC, "Y\0"},
-    {"1.1\0", 0xAE60, 0xDA45, 0x3E3E, 0x4BE1227E, "Y\0"},
-    {"1.2\0", 0xAE60, 0xDA45, 0x40BA, 0x0D8A132E, "Y\0"},
-    {"1.3\0", 0xB078, 0xDA45, 0x4006, 0xA8E60D9A, "Y\0"},
+    {'1.0\0', 0xAE5D, 0xDA84, 0x4002, 0xD8E9DFA7, 'Y\0'},
+    {'1.1\0', 0xAE60, 0xDA45, 0x40E0, 0x2DE3AFEC, 'Y\0'},
+    {'1.1\0', 0xAE60, 0xDA45, 0x3E3E, 0x4BE1227E, 'Y\0'},
+    {'1.2\0', 0xAE60, 0xDA45, 0x40BA, 0x0D8A132E, 'Y\0'},
+    {'1.3\0', 0xB078, 0xDA45, 0x4006, 0xA8E60D9A, 'Y\0'},
 
-    {"1.2\0", 0xAD8C, 0xDA45, 0x40BA, 0xB1ABA28D, "N\0"},
-    {"1.2\0", 0xAD8C, 0xDA45, 0x40BA, 0xFDC1F12C, "N\0"},
-    {"1.2\0", 0xAD8C, 0xDA45, 0x40BA, 0xD6FD9041, "N\0"},
+    {'1.2\0', 0xAD8C, 0xDA45, 0x40BA, 0xB1ABA28D, 'N\0'},
+    {'1.2\0', 0xAD8C, 0xDA45, 0x40BA, 0xFDC1F12C, 'N\0'},
+    {'1.2\0', 0xAD8C, 0xDA45, 0x40BA, 0xD6FD9041, 'N\0'},
 
-    {"1.3\0", 0xAED7, 0xDA45, 0x4006, 0x39F02E2F, "N\0"}};
+    {'1.3\0', 0xAED7, 0xDA45, 0x4006, 0x39F02E2F, 'N\0'}};
 
 int numberOfROMEntries = sizeof(romTable) / sizeof(romTable[0]);
 
 // Class constructor
-ROM::ROM(Model1 *model) : model1(model)
+ROM::ROM(ILogger *logger, Model1 *model)
 {
+  model1 = model;
+  _logger = logger;
 }
 
 void ROM::dump()
 {
-  Serial.println(F("----- BEGIN ROM DUMP -----"));
+  _logger->info("----- BEGIN ROM DUMP -----");
   getROMChecksum(true);
-  Serial.println(F("\n----- END ROM DUMP -----"));
+  _logger->info("\n----- END ROM DUMP -----");
 }
 
 // Get the ROM's checksum, also supports dumping ROM to ATMega's serial port
@@ -82,21 +84,15 @@ bool ROM::isROMValid(uint32_t crcValue, bool silent)
 {
   isValid = false;
 
-  SILENT_PRINT(silent, F("Known ROM versions: "));
-  SILENT_PRINTLN(silent, numberOfROMEntries);
-
-  SILENT_PRINT(silent, F("Checking if database has checksum/CRC32 value of: "));
-  SILENT_PRINTLN(silent, crcValue, HEX);
+  _logger->info("Known ROM versions: %d", numberOfROMEntries);
+  _logger->info("Checking if database has checksum/CRC32 value of: %X", crcValue);
 
   strcpy(romVersion, "Unknown\0");
   for (int i = 0; i < numberOfROMEntries; i++)
   {
     if (romTable[i].crc32 == crcValue)
     {
-      SILENT_PRINT(silent, "ROM match found: ");
-      SILENT_PRINT(silent, romTable[i].version);
-      SILENT_PRINT(silent, ", valid: ");
-      SILENT_PRINTLN(silent, romTable[i].valid);
+      _logger->info("ROM match found: %s, valid: %s", romTable[i].version, romTable[i].valid);
       strcpy(romVersion, romTable[i].version);
       isValid = true;
       break;
@@ -105,7 +101,7 @@ bool ROM::isROMValid(uint32_t crcValue, bool silent)
 
   if (!isValid)
   {
-    SILENT_PRINTLN(silent, F("Unknown ROM - contact RetroStack"));
+    _logger->info("Unknown ROM - contact RetroStack");
   }
 
   return isValid;

--- a/M1_Library/ROM.h
+++ b/M1_Library/ROM.h
@@ -6,6 +6,7 @@
 #include <Arduino.h>
 #include "CRC32.h"
 #include "Utils.h"
+#include "./ILogger.h"
 
 class Model1; // forward decleration
 
@@ -23,9 +24,8 @@ typedef struct
 class ROM
 {
 public:
-  ROM(Model1 *model);
+  ROM(ILogger *logger, Model1 *model);
 
-  ROM();
   void dump();
   uint32_t getROMChecksum(bool = true);
   bool isROMValid(uint32_t, bool = true);
@@ -34,6 +34,7 @@ public:
 
 private:
   Model1 *model1;
+  ILogger *_logger;
 
 protected:
 };

--- a/M1_Library/SerialLogger.cpp
+++ b/M1_Library/SerialLogger.cpp
@@ -1,0 +1,56 @@
+#include <arduino.h>
+
+#include "./SerialLogger.h"
+
+void SerialLogger::_log(const char *fmt, ...)
+{
+    va_list arguments;
+
+    const int LEN = 255;
+    char buffer[LEN];
+    snprintf(buffer, LEN, fmt, arguments);
+
+    Serial.println(buffer);
+}
+
+void SerialLogger::info(const char *fmt, ...)
+{
+    if (_silent)
+        return;
+
+    va_list arguments;
+
+    Serial.print("[INFO] ");
+    _log(fmt, arguments);
+}
+
+void SerialLogger::warn(const char *fmt, ...)
+{
+    if (_silent)
+        return;
+
+    va_list arguments;
+
+    Serial.print("[WARN] ");
+    _log(fmt, arguments);
+}
+
+void SerialLogger::err(const char *fmt, ...)
+{
+    if (_silent)
+        return;
+
+    va_list arguments;
+
+    Serial.print("[ERR ] ");
+    _log(fmt, arguments);
+}
+
+void SerialLogger::mute()
+{
+    _silent = true;
+}
+void SerialLogger::unmute()
+{
+    _silent = false;
+}

--- a/M1_Library/SerialLogger.h
+++ b/M1_Library/SerialLogger.h
@@ -1,0 +1,24 @@
+#ifndef SERIAL_LOGGER_H
+#define SERIAL_LOGGER_H
+
+#include <Arduino.h>
+
+#include "./ILogger.h"
+
+class SerialLogger : public ILogger
+{
+private:
+    bool _silent = false;
+
+    void _log(const char *fmt, ...);
+
+public:
+    void info(const char *fmt, ...);
+    void warn(const char *fmt, ...);
+    void err(const char *fmt, ...);
+
+    void mute();
+    void unmute();
+};
+
+#endif /* SERIAL_LOGGER_H */

--- a/M1_Library/Utils.cpp
+++ b/M1_Library/Utils.cpp
@@ -48,12 +48,6 @@ void asmWait(uint16_t outerLoopCount, uint16_t innerLoopCount)
   );
 }
 
-// Base case: When no more arguments are left, print a newline.
-void printLine()
-{
-  Serial.println();
-}
-
 // Wait for input
 uint8_t inputPrompt(const char *str)
 {
@@ -152,9 +146,4 @@ void convertHexStringToByteArray(char *hexString, unsigned char *byteArray)
     buffer[1] = hexString[2 * i + 1];
     byteArray[i] = (unsigned char)strtoul(buffer, NULL, 16);
   }
-}
-
-void printLine(const __FlashStringHelper *line)
-{
-  Serial.println(line);
 }

--- a/M1_Library/Utils.h
+++ b/M1_Library/Utils.h
@@ -9,18 +9,6 @@
 #define MAX_BUFFER_SIZE 100
 #define MAX_INPUT_PARAMETERS 5
 #define CPU_BUS_WAIT 7 // assume 16MHz arudino, asmWait is about 187.5ns per cycle, assume 1.77MHz Z80
-#define SILENT_PRINT(silentPrint, ...) \
-  do                                   \
-  {                                    \
-    if (!silentPrint)                  \
-      Serial.print(__VA_ARGS__);       \
-  } while (0)
-#define SILENT_PRINTLN(silentPrint, ...) \
-  do                                     \
-  {                                      \
-    if (!silentPrint)                    \
-      Serial.println(__VA_ARGS__);       \
-  } while (0)
 
 extern bool inGlobalTestMode; // State variable for test mode status
 extern bool isBUSAKWired;
@@ -46,18 +34,11 @@ void enterTestMode(bool silent = true);
 void exitTestMode(bool silent = true);
 
 // Called last from the variadic template function
-void printLine(); // Declaration of the non-template function
 void readSerialInput2();
 void readSerialInput(char *buffer, int bufferSize);
 
 // Template function definition
 template <typename T, typename... Types>
-
-void printLine(T first, Types... other)
-{
-  Serial.print(first);
-  printLine(other...);
-}
 
 uint8_t inputPrompt(const char *str);
 void serialFlush();

--- a/M1_Library/Video.h
+++ b/M1_Library/Video.h
@@ -6,8 +6,7 @@
 #include <Arduino.h>
 #include "Common.h"
 #include "CRC32.h"
-
-class Model1; // Forward declaration
+#include "./ILogger.h"
 
 #define VIDEO_COLS 64
 #define VIDEO_ROWS 16
@@ -16,29 +15,32 @@ class Model1; // Forward declaration
 #define VIDEO_MEM_END VIDEO_MEM_START + VIDEO_MEM_SIZE
 #define VIDEO_LAST_ROW (VIDEO_MEM_START + VIDEO_MEM_SIZE - VIDEO_COLS)
 
+class Model1; // forward decleration
+
 class Video
 {
 public:
-  Video(Model1 *model);
+  Video(ILogger *logger, Model1 *model);
 
   void init();
   bool checkVRAMFillChecksum(uint8_t fillValues[], int fillValuesCount);
   bool compareVRAMChecksum(uint32_t checksum);
-  bool lowercaseModExists(bool silent = true);
+  bool lowercaseModExists();
   void cls();
   void displayCharacterSet();
-  void fillVRAM(bool silent = true, uint8_t fillValue = 0x20, uint16_t start = VIDEO_MEM_START, uint16_t end = VIDEO_MEM_END);
-  void fillVRAMwithPattern(bool silent = true, const char *pattern = "5150", uint16_t start = VIDEO_MEM_START, uint16_t end = VIDEO_MEM_END);
+  void fillVRAM(uint8_t fillValue = 0x20, uint16_t start = VIDEO_MEM_START, uint16_t end = VIDEO_MEM_END);
+  void fillVRAMwithPattern(const char *pattern = "5150", uint16_t start = VIDEO_MEM_START, uint16_t end = VIDEO_MEM_END);
   void printToScreen(const char *str);
   void printToScreen(const char *str, uint16_t startAddress);
   void printToScreen(const char *str, unsigned int x, unsigned int y, bool updateCursorPosition = false);
   void printVideoUtilitiesMenu();
-  uint32_t readVRAM(bool silent = false, bool showInHex = true, bool dumpVRAM = false);
+  uint32_t readVRAM(bool showInHex = true, bool dumpVRAM = false);
   uint8_t readByteVRAM(uint16_t memAddress);
   void writeByteVRAM(uint16_t memAddress, uint8_t data);
 
 private:
   Model1 *model1;
+  ILogger *_logger;
   uint8_t videoData[VIDEO_MEM_SIZE];
   uint8_t memPattern[10];
   unsigned int cursorPosition;


### PR DESCRIPTION
The problem I see with the previous code is that there is always a forced output to Serial, even if serial isn't setup. This will cause issues. Additionally, there is no way to stop logging or even redirecting logging to another place if needed (for example LCD screen or something).

This change simply adds an interface for loggers. In addition, it adds a logger for the Serial interface (to support the previous code) and another logger which simply does not do anything.
As part of the logger, I added a differentiation between different logging levels, specifically "info", "warn" (warning), and "err" (error). For now, I just added everything to "info" and will make corrections as I go through the code once more in a follow-up pull request.

I also removed a few things that will be replaced by the logger itself.