### PR TITLE
Fix memory handling and comment typos

### DIFF
--- a/examples/Keyboard/Keyboard.ino
+++ b/examples/Keyboard/Keyboard.ino
@@ -25,7 +25,7 @@ void setup()
 
 void loop()
 {
-    // Check wether a key is pressed
+    // Check whether a key is pressed
     if (keyboard->isKeyPressed())
     {
 

--- a/examples/Model1/Model1.ino
+++ b/examples/Model1/Model1.ino
@@ -25,7 +25,7 @@ void loop()
 
     // Reads a block of length 300 from memory at location 0x3c00
     uint8_t *byte_array = model1->readMemory(0x3c00, 300);
-    free(byte_array); // Remember to free up memory when you don't need it anymore
+    delete[] byte_array; // Remember to free up memory when you don't need it anymore
 
     // Writes a byte value of 0x20 (spacebar) to location 0x3c00 in the video RAM
     model1->writeMemory(0x3c00, 0x20);
@@ -56,11 +56,11 @@ void loop()
     // Write 128 to the port 0x3F
     model1->writeIO(0x3f, 128);
 
-    // Determines wether the Model 1 system is in active reset
+    // Determines whether the Model 1 system is in active reset
     bool isInReset = model1->readSystemResetSignal();
 
     // Requests interrupt 0x2a to be triggered by the Z80
-    // wasTriggered determines wether the Z80 triggered the interrupt within timeout
+    // wasTriggered determines whether the Z80 triggered the interrupt within timeout
     bool wasTriggered = model1->triggerInterrupt(0x2a);
 
     // Activates the wait signal for the Z80, freezing it

--- a/examples/ROM/ROM.ino
+++ b/examples/ROM/ROM.ino
@@ -30,5 +30,5 @@ void loop()
     uint8_t *contents = rom->getContents();
 
     // Make sure to free up that memory again
-    free(contents);
+    delete[] contents;
 }

--- a/examples/Video/Video.ino
+++ b/examples/Video/Video.ino
@@ -65,7 +65,7 @@ void loop()
     video->print("RIGHT BOTTOM", 50, 15);
     delay(5000);
 
-    // Check wether the video mode is 64
+    // Check whether the video mode is 64
     bool is64Mode = video->is64Mode();
 
     // Set to 32 character mode

--- a/src/AddressBus.cpp
+++ b/src/AddressBus.cpp
@@ -97,7 +97,7 @@ void AddressBus::writeIOAddress(uint8_t address)
 }
 
 /**
- * Checks wether the bus is readable
+ * Checks whether the bus is readable
  */
 bool AddressBus::isReadable()
 {
@@ -105,7 +105,7 @@ bool AddressBus::isReadable()
 }
 
 /**
- * Checks wether the bus is writable
+ * Checks whether the bus is writable
  */
 bool AddressBus::isWritable()
 {

--- a/src/DataBus.cpp
+++ b/src/DataBus.cpp
@@ -53,7 +53,7 @@ void DataBus::writeData(uint8_t data)
 }
 
 /**
- * Checks wether bus is readable
+ * Checks whether bus is readable
  */
 bool DataBus::isReadable()
 {
@@ -61,7 +61,7 @@ bool DataBus::isReadable()
 }
 
 /**
- * Checks wether bus is writable
+ * Checks whether bus is writable
  */
 bool DataBus::isWritable()
 {

--- a/src/Keyboard.cpp
+++ b/src/Keyboard.cpp
@@ -24,7 +24,7 @@ Keyboard::Keyboard(Model1 *model1, ILogger *logger = nullptr)
 }
 
 /**
- * Checks wether any key is pressed at the moment
+ * Checks whether any key is pressed at the moment
  */
 bool Keyboard::isKeyPressed()
 {
@@ -32,7 +32,7 @@ bool Keyboard::isKeyPressed()
 }
 
 /**
- * Checks wether a shift key is pressed on the keyboard
+ * Checks whether a shift key is pressed on the keyboard
  */
 bool Keyboard::isShiftPressed()
 {

--- a/src/Model1.cpp
+++ b/src/Model1.cpp
@@ -117,7 +117,7 @@ EventData *Model1::_createEventData(uint8_t type)
 // ----------------------------------------
 
 /**
- * Checks wether an address is in the ROM address space
+ * Checks whether an address is in the ROM address space
  */
 bool Model1::isROMAddress(uint16_t address)
 {
@@ -125,7 +125,7 @@ bool Model1::isROMAddress(uint16_t address)
 }
 
 /**
- * Checks wether an address is in the unused address space
+ * Checks whether an address is in the unused address space
  */
 bool Model1::isUnusedAddress(uint16_t address)
 {
@@ -133,7 +133,7 @@ bool Model1::isUnusedAddress(uint16_t address)
 }
 
 /**
- * Checks wether an address is in the memory-mapped IO address space
+ * Checks whether an address is in the memory-mapped IO address space
  */
 bool Model1::isMemoryMappedIOAddress(uint16_t address)
 {
@@ -141,7 +141,7 @@ bool Model1::isMemoryMappedIOAddress(uint16_t address)
 }
 
 /**
- * Checks wether an address is in the keyboard address space
+ * Checks whether an address is in the keyboard address space
  */
 bool Model1::isKeyboardAddress(uint16_t address)
 {
@@ -149,7 +149,7 @@ bool Model1::isKeyboardAddress(uint16_t address)
 }
 
 /**
- * Checks wether an address is in the video address space
+ * Checks whether an address is in the video address space
  */
 bool Model1::isVideoAddress(uint16_t address)
 {
@@ -157,7 +157,7 @@ bool Model1::isVideoAddress(uint16_t address)
 }
 
 /**
- * Checks wether an address is in the system address space
+ * Checks whether an address is in the system address space
  */
 bool Model1::isSystemAddress(uint16_t address)
 {
@@ -165,7 +165,7 @@ bool Model1::isSystemAddress(uint16_t address)
 }
 
 /**
- * Checks wether an address is in the lower memory address space
+ * Checks whether an address is in the lower memory address space
  */
 bool Model1::isLowerMemoryAddress(uint16_t address)
 {
@@ -173,7 +173,7 @@ bool Model1::isLowerMemoryAddress(uint16_t address)
 }
 
 /**
- * Checks wether an address is in the higher memory address space
+ * Checks whether an address is in the higher memory address space
  */
 bool Model1::isHigherMemoryAddress(uint16_t address)
 {
@@ -209,7 +209,7 @@ void Model1::_setMutability(bool value)
 }
 
 /**
- * Checks wether
+ * Checks whether the system is mutable
  */
 bool Model1::_isMutable()
 {
@@ -394,9 +394,9 @@ void Model1::writeMemory(uint16_t address, uint8_t data)
 uint8_t *Model1::readMemory(uint16_t address, uint16_t length)
 {
     if (length == 0)
-        return;
+        return nullptr;
 
-    uint8_t *buffer = new uint8_t(length);
+    uint8_t *buffer = new uint8_t[length];
     for (uint16_t i = 0; i < length; i++)
     {
         buffer[i] = readMemory(address + i);
@@ -532,7 +532,7 @@ void Model1::triggerMemoryReadEvent()
     {
         EventData *data = _createEventData(EVENT_MEMORY_READ);
         _memoryReadCallback(*data);
-        free(data);
+        delete data;
     }
 }
 
@@ -553,7 +553,7 @@ void Model1::triggerMemoryWriteEvent()
     {
         EventData *data = _createEventData(EVENT_MEMORY_WRITE);
         _memoryWriteCallback(*data);
-        free(data);
+        delete data;
     }
 }
 
@@ -681,7 +681,7 @@ void Model1::triggerIOReadEvent()
     {
         EventData *data = _createEventData(EVENT_IO_READ);
         _ioReadCallback(*data);
-        free(data);
+        delete data;
     }
 }
 
@@ -702,7 +702,7 @@ void Model1::triggerIOWriteEvent()
     {
         EventData *data = _createEventData(EVENT_IO_WRITE);
         _ioWriteCallback(*data);
-        free(data);
+        delete data;
     }
 }
 
@@ -722,7 +722,7 @@ void Model1::_initSystemControlSignals()
 }
 
 /**
- * Reads wether a system reset has occurred.
+ * Reads whether a system reset has occurred.
  */
 bool Model1::readSystemResetSignal()
 {
@@ -730,7 +730,7 @@ bool Model1::readSystemResetSignal()
 }
 
 /**
- * Reads wether the CPU has acknowledged an interrupt request.
+ * Reads whether the CPU has acknowledged an interrupt request.
  */
 bool Model1::readInterruptAcknowledgeSignal()
 {
@@ -1074,8 +1074,8 @@ char *Model1::getState()
         pinStatus(pinConfigRead(TEST)), pinRead(TEST),
         pinStatus(pinConfigRead(WAIT)), pinRead(WAIT));
 
-    free(addrStatus);
-    free(dataStatus);
+    delete[] addrStatus;
+    delete[] dataStatus;
 
     return buffer;
 }
@@ -1089,7 +1089,7 @@ void Model1::logState()
     {
         char *state = getState();
         _logger->info("State: %s", state);
-        free(state);
+        delete[] state;
     }
 }
 

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -443,7 +443,7 @@ void Video::print(const char *str, uint16_t length, uint8_t x, uint8_t y)
 }
 
 /**
- * Checks wether video mode is in 64 characters
+ * Checks whether video mode is in 64 characters
  */
 bool Video::is64Mode()
 {


### PR DESCRIPTION
## Summary
- correct "whether" spelling across the project
- allocate arrays with `new[]` and free with `delete`/`delete[]`
- return `nullptr` when zero bytes requested in `readMemory`

## Testing
- `git log -1 --stat`
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8c2b9814832c84f18815baff4f05