### PR TITLE
Fix duplicate default arguments

### DIFF
--- a/src/AddressBus.cpp
+++ b/src/AddressBus.cpp
@@ -15,7 +15,7 @@ void AddressBus::_configurePort(uint8_t config)
 /**
  * Initializes the Bus Access
  */
-AddressBus::AddressBus(ILogger *logger = nullptr)
+AddressBus::AddressBus(ILogger *logger)
 {
     _logger = logger;
     _writable = false;

--- a/src/Cassette.cpp
+++ b/src/Cassette.cpp
@@ -8,7 +8,7 @@ const uint8_t CASSETTE_PORT = 0xff;
 /**
  * Initializes the cassette interface
  */
-Cassette::Cassette(Model1 *model1, ILogger *logger = nullptr)
+Cassette::Cassette(Model1 *model1, ILogger *logger)
 {
     _model1 = model1;
     _logger = logger;

--- a/src/DataBus.cpp
+++ b/src/DataBus.cpp
@@ -14,7 +14,7 @@ void DataBus::_configurePort(uint8_t config)
 /**
  * Initializes the data bus
  */
-DataBus::DataBus(ILogger *logger = nullptr)
+DataBus::DataBus(ILogger *logger)
 {
   _logger = logger;
   _writable = false;

--- a/src/Keyboard.cpp
+++ b/src/Keyboard.cpp
@@ -17,7 +17,7 @@ const uint8_t lookupTable[8][8] = {
     {0x0D, 0x1F, 0x01, 0x5B, 0x0A, 0x08, 0x09, 0x20}, // 3840
 };
 
-Keyboard::Keyboard(Model1 *model1, ILogger *logger = nullptr)
+Keyboard::Keyboard(Model1 *model1, ILogger *logger)
 {
   _model1 = model1;
   _logger = logger;

--- a/src/Model1.cpp
+++ b/src/Model1.cpp
@@ -18,7 +18,7 @@ Model1 *globalModel1 = nullptr;
  *
  * @param logger
  */
-Model1::Model1(ILogger *logger = nullptr)
+Model1::Model1(ILogger *logger)
 {
     _logger = logger;
 

--- a/src/ROM.cpp
+++ b/src/ROM.cpp
@@ -6,7 +6,7 @@
 const uint16_t ROM_START = 0x00;
 const uint16_t ROM_LENGTH = 1024 * 12; // 12k
 
-ROM::ROM(Model1 *model1, ILogger *logger = nullptr)
+ROM::ROM(Model1 *model1, ILogger *logger)
 {
   _model1 = model1;
   _logger = logger;

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -12,7 +12,7 @@ const uint8_t CASSETTE_PORT = 0xff;
 /**
  * Initializes the TRS-80 Model 1 Video Subsystem
  */
-Video::Video(Model1 *model1, ILogger *logger = nullptr)
+Video::Video(Model1 *model1, ILogger *logger)
 {
   _model1 = model1;
   _logger = logger;
@@ -29,7 +29,7 @@ Video::Video(Model1 *model1, ILogger *logger = nullptr)
 /**
  * Initializes the TRS-80 Model 1 Video Subsystem with custom viewport
  */
-Video::Video(Model1 *model1, ViewPort viewPort, ILogger *logger = nullptr)
+Video::Video(Model1 *model1, ViewPort viewPort, ILogger *logger)
 {
   _model1 = model1;
   _logger = logger;


### PR DESCRIPTION
## Summary
- remove redundant default values for logger arguments in constructor implementations

No tests provided in repo.

------
https://chatgpt.com/codex/tasks/task_e_685ee36983ac832c8a5d7ac6eefa17c7