### PR TITLE
Fix dynamic array allocation

### DIFF
--- a/examples/ROM/ROM.ino
+++ b/examples/ROM/ROM.ino
@@ -27,8 +27,8 @@ void loop()
 {
     // Request the full contents of the ROM
     // It reads all of the 12k of ROM and returns it as a byte array.
-    uint8_t *contents = rom->getContents();
+    uint8_t *contents = rom->getContent();
 
     // Make sure to free up that memory again
-    free(contents);
+    delete[] contents;
 }

--- a/src/AddressBus.cpp
+++ b/src/AddressBus.cpp
@@ -15,7 +15,7 @@ void AddressBus::_configurePort(uint8_t config)
 /**
  * Initializes the Bus Access
  */
-AddressBus::AddressBus(ILogger *logger = nullptr)
+AddressBus::AddressBus(ILogger *logger)
 {
     _logger = logger;
     _writable = false;

--- a/src/Cassette.cpp
+++ b/src/Cassette.cpp
@@ -8,7 +8,7 @@ const uint8_t CASSETTE_PORT = 0xff;
 /**
  * Initializes the cassette interface
  */
-Cassette::Cassette(Model1 *model1, ILogger *logger = nullptr)
+Cassette::Cassette(Model1 *model1, ILogger *logger)
 {
     _model1 = model1;
     _logger = logger;

--- a/src/DataBus.cpp
+++ b/src/DataBus.cpp
@@ -14,7 +14,7 @@ void DataBus::_configurePort(uint8_t config)
 /**
  * Initializes the data bus
  */
-DataBus::DataBus(ILogger *logger = nullptr)
+DataBus::DataBus(ILogger *logger)
 {
   _logger = logger;
   _writable = false;

--- a/src/Keyboard.cpp
+++ b/src/Keyboard.cpp
@@ -17,7 +17,7 @@ const uint8_t lookupTable[8][8] = {
     {0x0D, 0x1F, 0x01, 0x5B, 0x0A, 0x08, 0x09, 0x20}, // 3840
 };
 
-Keyboard::Keyboard(Model1 *model1, ILogger *logger = nullptr)
+Keyboard::Keyboard(Model1 *model1, ILogger *logger)
 {
   _model1 = model1;
   _logger = logger;

--- a/src/Model1.cpp
+++ b/src/Model1.cpp
@@ -18,7 +18,7 @@ Model1 *globalModel1 = nullptr;
  *
  * @param logger
  */
-Model1::Model1(ILogger *logger = nullptr)
+Model1::Model1(ILogger *logger)
 {
     _logger = logger;
 
@@ -394,9 +394,9 @@ void Model1::writeMemory(uint16_t address, uint8_t data)
 uint8_t *Model1::readMemory(uint16_t address, uint16_t length)
 {
     if (length == 0)
-        return;
+        return nullptr;
 
-    uint8_t *buffer = new uint8_t(length);
+    uint8_t *buffer = new uint8_t[length];
     for (uint16_t i = 0; i < length; i++)
     {
         buffer[i] = readMemory(address + i);

--- a/src/Model1.h
+++ b/src/Model1.h
@@ -101,6 +101,7 @@ public:
     // ---------- Memory
     uint8_t readMemory(uint16_t address);
     void writeMemory(uint16_t address, uint8_t data);
+    // Returns a newly allocated buffer; caller must delete[] the result
     uint8_t *readMemory(uint16_t address, uint16_t length);
     void writeMemory(uint16_t address, uint8_t *data, uint16_t length);
     void writeMemory(uint16_t address, uint8_t *data, uint16_t length, uint16_t offset);

--- a/src/ROM.cpp
+++ b/src/ROM.cpp
@@ -6,7 +6,7 @@
 const uint16_t ROM_START = 0x00;
 const uint16_t ROM_LENGTH = 1024 * 12; // 12k
 
-ROM::ROM(Model1 *model1, ILogger *logger = nullptr)
+ROM::ROM(Model1 *model1, ILogger *logger)
 {
   _model1 = model1;
   _logger = logger;

--- a/src/ROM.h
+++ b/src/ROM.h
@@ -20,7 +20,7 @@ private:
 public:
   ROM(Model1 *model1, ILogger *logger = nullptr);
 
-  uint8_t *ROM::getContent();
+  uint8_t *getContent();
 };
 
 #endif // ROM_H

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -12,7 +12,7 @@ const uint8_t CASSETTE_PORT = 0xff;
 /**
  * Initializes the TRS-80 Model 1 Video Subsystem
  */
-Video::Video(Model1 *model1, ILogger *logger = nullptr)
+Video::Video(Model1 *model1, ILogger *logger)
 {
   _model1 = model1;
   _logger = logger;
@@ -29,7 +29,7 @@ Video::Video(Model1 *model1, ILogger *logger = nullptr)
 /**
  * Initializes the TRS-80 Model 1 Video Subsystem with custom viewport
  */
-Video::Video(Model1 *model1, ViewPort viewPort, ILogger *logger = nullptr)
+Video::Video(Model1 *model1, ViewPort viewPort, ILogger *logger)
 {
   _model1 = model1;
   _logger = logger;


### PR DESCRIPTION
## Summary
- allocate buffers with `new[]` in `Model1::readMemory`
- clarify header that caller must `delete[]` the returned buffer
- update example to use `delete[]` instead of `free`

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee36983ac832c8a5d7ac6eefa17c7